### PR TITLE
remove group and user resources

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -17,11 +17,6 @@ class xrootd::config (
     unless  => "ls ${grid_security}/certificates/*.r0"
   }
   
-  group { $xrootd_group: } ->
-  user { $xrootd_user: 
-    gid => $xrootd_group,
-  }
-  
   File {
     owner  => $xrootd_user,
     group  => $xrootd_group,


### PR DESCRIPTION
Remove group and user resource definition to allow external definition as required.

The current explicit definition of group and user resources conflicts with external definitions of group/user. This makes it impossible to set uid/gid/comments/... of the group/user resource type.

The change makes user/group an external requirement, just like xrootd itself must be installed. The official xrootd packages also create the user/group ``xrootd``; in most cases, satisfying the xrootd requirement would already satisfy the user/group requirement.