### PR TITLE
config: Fix fetchcrl dependency.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,13 +10,11 @@ class xrootd::config (
   $grid_security = $xrootd::params::grid_security,
 ) inherits xrootd::params {
   
-  # Rely on this class to be known to Puppet in some way.
-  include fetchcrl
-  
   exec {'run-fetchcrl-atleastonce':
     path    => '/bin:/usr/bin:/sbin:/usr/sbin',
     command => 'fetch-crl',
-    unless  => "ls -U ${grid_security}/certificates/*.r0"
+    unless  => "ls -U ${grid_security}/certificates/*.r0",
+    require => Class['fetchcrl'],
   }
   
   ensure_resource('group', $xrootd_group_name, $xrootd_group)


### PR DESCRIPTION
By including fetchcrl explicitly, it would also be instantiated.
Leave that to the user, just require that is has been instantiated,
otherwise it might be instantiated twice, disallowing user
configuration of fetchcrl.