### PR TITLE
Rename exec resource for systemctl daemon-reload.

### DIFF
--- a/manifests/create_systemd.pp
+++ b/manifests/create_systemd.pp
@@ -17,6 +17,6 @@ define xrootd::create_systemd (
     owner   => root,
     group   => root,
     content => template('xrootd/override.erb'),
-  }  ~> Exec['systemctl-daemon-reload']
+  }  ~> Exec['systemctl-daemon-reload-xrootd']
 
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,7 +5,7 @@ class xrootd::service (
   $key	= $xrootd::params::key,
 ) inherits xrootd::params {
 
-  exec {'systemctl-daemon-reload':
+  exec {'systemctl-daemon-reload-xrootd':
     command     => '/usr/bin/systemctl daemon-reload',
     refreshonly => true,
   }


### PR DESCRIPTION
The name "systemctl-daemon-reload" is likely to clash with
other puppet modules. It collides for example with voxpopuli/zabbix.

Signed-off-by: Oliver Freyermuth <freyermuth@physik.uni-bonn.de>

I'll also open a PR against voxpopuli/zabbix soonish. 